### PR TITLE
Added async loop in init

### DIFF
--- a/giphypy/client.py
+++ b/giphypy/client.py
@@ -5,7 +5,6 @@ import requests
 
 import aiohttp
 
-
 from .constants import API_URL
 from .errors import GiphyPyError, GiphyPyKeyError
 

--- a/giphypy/client.py
+++ b/giphypy/client.py
@@ -13,7 +13,7 @@ class Giphy:
     https://developers.giphy.com
     """
     def __init__(self, api_key, loop: Optional[asyncio.BaseEventLoop] = None,
-        session: aiohttp.ClientSession = None):
+                 session: aiohttp.ClientSession = None):
         """
         :param api_key: Giphy API key, required.
         """
@@ -23,7 +23,6 @@ class Giphy:
         self.api_key = api_key
         self.loop = loop or asyncio.get_event_loop()
         self.session = session or aiohttp.ClientSession(loop=self.loop)
-
 
     async def _get(self, api_endpoint: str, **kwargs):
         """

--- a/giphypy/client.py
+++ b/giphypy/client.py
@@ -1,4 +1,7 @@
 import requests
+import asyncio
+import aiohttp
+from typing import Optional
 
 from .constants import API_URL
 from .errors import GiphyPyError, GiphyPyKeyError
@@ -9,13 +12,18 @@ class Giphy:
     Wrapper for the Giphy api. Keys can be optained from:
     https://developers.giphy.com
     """
-    def __init__(self, api_key):
+    def __init__(self, api_key, loop: Optional[asyncio.BaseEventLoop] = None,
+        session: aiohttp.ClientSession = None):
         """
         :param api_key: Giphy API key, required.
         """
         if not api_key:
             raise GiphyPyKeyError
+
         self.api_key = api_key
+        self.loop = loop or asyncio.get_event_loop()
+        self.session = session or aiohttp.ClientSession(loop=self.loop)
+
 
     async def _get(self, api_endpoint: str, **kwargs):
         """

--- a/giphypy/client.py
+++ b/giphypy/client.py
@@ -1,6 +1,7 @@
-import requests
 import asyncio
+import requests
 import aiohttp
+
 from typing import Optional
 
 from .constants import API_URL

--- a/giphypy/client.py
+++ b/giphypy/client.py
@@ -1,8 +1,10 @@
 import asyncio
+from typing import Optional
+
 import requests
+
 import aiohttp
 
-from typing import Optional
 
 from .constants import API_URL
 from .errors import GiphyPyError, GiphyPyKeyError


### PR DESCRIPTION
@MichaelYusko , have added the loop into `__init__` and now we have no await error.

>>> from giphypy.client import Giphy
>>> token = '29fab2043bde498ca29834ef4fde3cef'
>>> c = Giphy(token)
>>> data = c.search('apple')
>>> print(data)
>>> <coroutine object Giphy.search at 0x109a72e08>
