### PR TITLE
Refactor/require python3.5

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,14 +33,14 @@ sys.path.insert(0, os.path.abspath('..'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.ifconfig',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages']
+              'sphinx.ext.doctest',
+              'sphinx.ext.intersphinx',
+              'sphinx.ext.todo',
+              'sphinx.ext.coverage',
+              'sphinx.ext.mathjax',
+              'sphinx.ext.ifconfig',
+              'sphinx.ext.viewcode',
+              'sphinx.ext.githubpages']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -180,8 +180,6 @@ texinfo_documents = [
      author, 'GiphyPy', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
 
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import giphypy
 from setuptools import setup
-
+import sys
 
 version = giphypy.__version__
 
@@ -22,5 +22,17 @@ setup_kwargs = {
         'License :: OSI Approved :: MIT License'
     ],
  }
+
+if sys.version_info < (3, 5):
+    """
+    If python version is less than 2.5, exit else proceed
+    """
+    print('\n\033[91m[Error]\033[0m: '
+          'giphypy requires Python version >= 3.5.\n\t '
+          'You are currently using Python {}\n\t '
+          'Exiting...\n'
+          .format(sys.version.split('(')[0].strip()))
+
+    sys.exit()
 
 setup(**setup_kwargs)


### PR DESCRIPTION
Added check for python version to setup.py.  
If version is less than 3.5 then show error and exit, else proceed for setup.
![screenshot from 2017-07-12 19-35-47](https://user-images.githubusercontent.com/15676805/28121642-6651bfe0-6739-11e7-8498-413a8191615e.png)
![screenshot from 2017-07-12 19-38-29](https://user-images.githubusercontent.com/15676805/28121769-bef5b390-6739-11e7-8fff-41e60fa10ff8.png)

